### PR TITLE
RPC client returns ApplicationErrors and we want to handle them

### DIFF
--- a/lib/json-rpc-objects/v10/request.rb
+++ b/lib/json-rpc-objects/v10/request.rb
@@ -133,7 +133,7 @@ module JsonRpcObjects
             #
             
             def __check_method
-                if not (@method.kind_of?(Symbol) or @method.kind_of?(String)) 
+                if not (@method.kind_of?(Symbol) or @method.kind_of?(String))
                     raise Exception::new("Service name must be Symbol or convertable to Symbol.")
                 end
             end
@@ -143,7 +143,7 @@ module JsonRpcObjects
             #
             
             def __check_params
-                if not @params.array?
+                if not @params.kind_of?(Array)
                     raise Exception::new("Params must be Array.")
                 end
             end

--- a/lib/json-rpc-objects/v11/alt/service-procedure-description.rb
+++ b/lib/json-rpc-objects/v11/alt/service-procedure-description.rb
@@ -47,8 +47,8 @@ module JsonRpcObjects
                 
                 def check!
                     super()
-                    
-                    if @params.array? and (not @params.all? { |v| v.type != JsonRpcObjects::V11::GenericTypes::Nil })
+
+                    if @params.kind_of?(Array) and (not @params.all? { |v| v.type != JsonRpcObjects::V11::GenericTypes::Nil })
                         raise Exception::new("Nil return type isn't allowed for parameters.")
                     end
                 end

--- a/lib/json-rpc-objects/v11/wd/procedure-call.rb
+++ b/lib/json-rpc-objects/v11/wd/procedure-call.rb
@@ -64,8 +64,8 @@ module JsonRpcObjects
                 
                 def check!
                     super()
-                    
-                    if not @keyword_params.nil? and not @keyword_params.hash?
+
+                    if not @keyword_params.nil? and not @keyword_params.kind_of?(Hash)
                         raise Exception::new("Keyword params must be Hash.")
                     end
                 end
@@ -143,8 +143,8 @@ module JsonRpcObjects
                 
                     # If named arguments used, assigns keys as symbols
                     #   but keeps numeric arguments as integers
-                    
-                    if @params.hash?
+
+                    if @params.kind_of?(Hash)
                         @params = @params.dup
                         @keyword_params = @params.remove! { |k, v| not k.numeric? }
                         @params = @params.sort_by { |i| i.first.to_i }.map { |i| i.second }

--- a/lib/json-rpc-objects/v11/wd/procedure-parameter-description.rb
+++ b/lib/json-rpc-objects/v11/wd/procedure-parameter-description.rb
@@ -98,12 +98,12 @@ module JsonRpcObjects
                 
                 def check!
                     self.normalize!
-                    
-                    if not @name.symbol?
+
+                    if not @name.kind_of?(Symbol)
                         raise Exception::new("Parameter name must be Symbol or convertable to Symbol.")
                     end
-                    
-                    if (not @type.nil?) and (not @type.kind_of_any? [GenericTypes::Any, GenericTypes::Nil, GenericTypes::Boolean, Integer, String, Array, Object])
+
+                    if (not @type.nil?) and (not [GenericTypes::Any, GenericTypes::Nil, GenericTypes::Boolean, Integer, String, Array, Object].any? {|c| @type.kind_of?(c)})
                         raise Exception::new("Type if defined can be only Any, Nil, Boolean, Integer, String, Array or Object.")
                     end
                 end
@@ -147,8 +147,9 @@ module JsonRpcObjects
                         @name = @name.to_sym
                     end
 
-                    if @type.kind_of_any? [String, Symbol]
+                    if [String, Symbol].any? {|c| @type.kind_of?(c) }
                         @type = __normalize_type
+                    }
                     end
                 end
                 

--- a/lib/json-rpc-objects/v11/wd/service-description.rb
+++ b/lib/json-rpc-objects/v11/wd/service-description.rb
@@ -130,21 +130,21 @@ module JsonRpcObjects
                 
                 def check!
                     self.normalize!
-                    
-                    if not @name.symbol?
+
+                    if not @name.kind_of?(Symbol)
                         raise Exception::new("Service name must be Symbol or convertable to Symbol.")
                     end
 
                     if not (@version.nil?) and not @version.match(self.class::VERSION_MATCHER)
                         raise Exception::new("Version must be at least in <major>.<minor> format and must contain numbers only.")
                     end
-                    
-                    if (not @procs.nil?) 
-                        if (not @procs.array?) or (not @procs.all? { |v| v.kind_of? self.class::PROCEDURE_DESCRIPTION_CLASS })
+
+                    if (not @procs.nil?)
+                        if (not @procs.kind_of?(Array)) or (not @procs.all? { |v| v.kind_of? self.class::PROCEDURE_DESCRIPTION_CLASS })
                             raise Exception::new("If procs is defined, must be an Array of " << self.class::PROCEDURE_DESCRIPTION_CLASS.name << " objects.")
                         end
-                        
-                        if @procs.array?
+
+                        if @procs.kind_of?(Array)
                             @procs.each { |proc| proc.check! }
                         end
                     end
@@ -222,8 +222,8 @@ module JsonRpcObjects
                     @help = data[:help]
                     @address = data[:address]
                     @procs = data[:procs]
-                    
-                    if @procs.array?
+
+                    if @procs.kind_of?(Array)
                         @procs = @procs.map { |v| self.class::PROCEDURE_DESCRIPTION_CLASS::new(v) }
                     end
                 end

--- a/lib/json-rpc-objects/v11/wd/service-procedure-description.rb
+++ b/lib/json-rpc-objects/v11/wd/service-procedure-description.rb
@@ -110,17 +110,17 @@ module JsonRpcObjects
                 
                 def check!
                     self.normalize!
-                    
-                    if not @name.symbol?
+
+                    if not @name.kind_of?(Symbol)
                         raise Exception::new("Procedure name must be Symbol or convertable to Symbol.")
                     end
 
-                    if not @params.nil? 
-                        if (not @params.array?) or (not @params.all? { |v| v.kind_of? self.class::PARAMETER_DESCRIPTION_CLASS })
+                    if not @params.nil?
+                        if (not @params.kind_of?(Array)) or (not @params.all? { |v| v.kind_of? self.class::PARAMETER_DESCRIPTION_CLASS })
                             raise Exception::new("If params is defined, must be an Array of " << self.class::PARAMETER_DESCRIPTION_CLASS.name << " objects.")
                         end
-                        
-                        if @params.array?
+
+                        if @params.kind_of?(Array)
                             @params.each { |param| param.check! }
                         end
                     end
@@ -205,12 +205,12 @@ module JsonRpcObjects
                     @idempotent = data[:idempotent]
                     @params = data[:params]
                     @return = data[:return]
-                    
-                    if @params.array?
+
+                    if @params.kind_of?(Array)
                         @params = @params.map { |v| self.class::PARAMETER_DESCRIPTION_CLASS::new(v) }
                     end
-                    
-                    if @return.hash?
+
+                    if @return.kind_of?(Hash)
                         @return = self.class::PARAMETER_DESCRIPTION_CLASS::new(@return)
                     end
                 end

--- a/lib/json-rpc-objects/v20/error.rb
+++ b/lib/json-rpc-objects/v20/error.rb
@@ -19,25 +19,25 @@ module JsonRpcObjects
         ##
         # Error description object class for Response.
         #
-        
+
         class Error < JsonRpcObjects::V11::Alt::Error
-        
+
             ##
             # Holds link to its version module.
             #
-            
+
             VERSION = JsonRpcObjects::V20
 
             ##
             # Indicates data member name.
             #
-            
+
             DATA_MEMBER_NAME = :data
-            
+
             ##
             # Checks correctness of the data.
             #
-            
+
             def check!
                 self.normalize!
 
@@ -52,29 +52,29 @@ module JsonRpcObjects
             # Renders data to output hash.
             # @return [Hash] with data of error
             #
-            
+
             def output
                 result = super()
-                
+
                 if result.include? "error"
                     result["data"] = result["error"]
                     result.delete("error")
                 end
-            
+
                 return result
             end
-            
-            
+
+
             protected
-            
+
             ##
             # Assigns error data.
             #
-            
+
             def __assign_data(data)
                 @data = data[:data]
                 data.delete(:data)
-                
+
                 if @data.nil?
                     super(data)
                 end

--- a/lib/json-rpc-objects/v20/error.rb
+++ b/lib/json-rpc-objects/v20/error.rb
@@ -40,12 +40,13 @@ module JsonRpcObjects
 
             def check!
                 self.normalize!
+                # our RPC client returns ApplicationErrors and we want to handle them
+                # this shouldn't be Exception.new but defined error class
+                # if ((-32768..-32000).include?(@code)) and not ((@code == -32700) or
+                #      ((-32603..-32600).include?(@code)) or ((-32099..-32000).include?(code)))
 
-                if ((-32768..-32000).include?(@code)) and not ((@code == -32700) or
-                     ((-32603..-32600).include?(@code)) or ((-32099..-32000).include?(code)))
-
-                    raise Exception::new("Code is invalid because of reserved space.")
-                end
+                #     raise Exception::new("Code is invalid because of reserved space.")
+                # end
             end
 
             ##


### PR DESCRIPTION
This is not a ready solution but just a quick fix which I had to do it.

`raise Exception::new` it's not the best idea. There is no way to catch this. 
There are a lot more place in the code where you raise Exception.new there should be changed to defined error class
